### PR TITLE
search engine - products only and see only your own orders

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,7 +1,7 @@
 class OrdersController < ApplicationController
 
   def index
-    @orders = Order.all
+    @orders = current_user.orders
   end
 
   def new

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,11 @@ class ProductsController < ApplicationController
     skip_before_action :authenticate_user!, only: %i[index show]
 
   def index
-    @products = Product.all
+    if params[:query].present?
+      @products = Product.where("name ILIKE ?", "%#{params[:query]}%")
+    else
+      @products = Product.all
+    end
   end
 
   def show

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -3,4 +3,4 @@
 <% @orders.each do |order| %>
   <p><%=order.product.name%> - $<%=order.product.unit_price%> - <%=order.created_at.strftime("%d/%m/%Y")%> </p>
 <%end%>
-<%=link_to "Back", root_path%>
+<%=link_to "Back", products_path%>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,2 +1,10 @@
 <h1>Pages#home</h1>
 <p>Find me in app/views/pages/home.html.erb</p>
+<%= form_tag products_path, method: :get do %>
+  <%= text_field_tag :query,
+    params[:query],
+    class: "form-control",
+    placeholder: "Find a product"
+  %>
+  <%= submit_tag "Search", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -19,12 +19,6 @@
         <li class="nav-item active">
           <%= link_to "Home", root_path, class: "nav-link" %>
         </li>
-        <%# <li class="nav-item">
-          <%= link_to "Sell", "products/new", class: "nav-link" %>
-        <%# </li> %>
-        <%# <li class="nav-item"> %>
-          <%# <%= link_to "My orders", "#", class: "nav-link" %>
-        <%# </li> %>
         <li class="nav-item dropdown">
           <%= image_tag "user_icon.jpg", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: "products#index"
+  root to: "pages#home"
+
 
   resources :products, only: %i[new create index show] do
     resources :orders, only: [ :new, :create ]


### PR DESCRIPTION
Somente permite que os pedidos do próprio usuário logado seja visualizadas. Início da implementção do search engine. Busca está sendo realizada apenas por produto e não por endereço.